### PR TITLE
Fix TTL for Redis keys

### DIFF
--- a/haystack_memory/utils.py
+++ b/haystack_memory/utils.py
@@ -78,13 +78,14 @@ class RedisUtils:
         Internal function to store the initial query and the answer of the agent to the memory
         :param result: Transcript of the agent
         """
-        if not self.__expiration_is_set:
-            self.redis.expire(self.memory_id, self.expiration)
-            self.__expiration_is_set = True
+
         self.redis.rpush(self.memory_id, result["query"])
         self.__transfer_sensory_memory(result)
         self.redis.rpush(self.memory_id, result["answers"][0].answer)
-
+        if not self.__expiration_is_set:
+            self.redis.expire(self.memory_id, self.expiration)
+            self.__expiration_is_set = True
+            
     def chat(self,
              query: str):
         """


### PR DESCRIPTION
Currently the TTL doesnt work because the key doesn't exist when the TTL is being set.  Move the setting of the TTL below the creation of the key.